### PR TITLE
Don't benchmark disk speed using tmpfs

### DIFF
--- a/luks-encryption-manual-tpm-ssh-unlock/README.md
+++ b/luks-encryption-manual-tpm-ssh-unlock/README.md
@@ -571,7 +571,7 @@ cryptsetup benchmark
 To test the disk benchmark run:
 
 ```
-dd if=/dev/zero of=/tmp/write_test.img bs=1G count=1 oflag=dsync; rm /tmp/write_test.img
+dd if=/dev/zero of=write_test.img bs=1G count=1 oflag=dsync; rm write_test.img
 ```
 
 # Enable LUKS for root partition


### PR DESCRIPTION
/tmp is typically mounted using in-memory tmpfs nowadays. Testing by writing a file there doesn't test disk speed, but memory speed.